### PR TITLE
Issue-#1: Don't break with invalid HPO terms in batch-POST similarity request

### DIFF
--- a/pyhpoapi/helpers.py
+++ b/pyhpoapi/helpers.py
@@ -67,5 +67,6 @@ def get_hpo_set(set_query: str) -> HPOSet:
     except Exception:
         raise HTTPException(
             status_code=400,
-            detail='Invalid query'
+            detail='Invalid query',
+            headers={'X-Error': 'Invalid query provided'}
         )

--- a/pyhpoapi/routers/terms.py
+++ b/pyhpoapi/routers/terms.py
@@ -377,7 +377,9 @@ async def batch_similarity(
             )
         except HTTPException as ex:
             res['similarity'] = None
-            res['error'] = ex.headers['X-TermNotFound']  # type: ignore
+            res['error'] = ex.headers.get(
+                'X-TermNotFound', 'Unknown error'
+            )  # type: ignore
 
         other_sets.append(res)
     return {


### PR DESCRIPTION
Fixes a bug where similarity requests in batch would fail if one set contained wrong HPO-term identifiers